### PR TITLE
Shorten parameter lists by containing StorageEngine, TransactionIdStore, and LogFiles into new CoreBuildStore class

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
@@ -30,19 +30,19 @@ public class CoreBuildStore {
         return logFiles;
     }
 
-    public void setTransactionIdStore(TransactionIdStore transactionIdStore) {
+    public void setTransactionIdStore( TransactionIdStore transactionIdStore ) {
         this.transactionIdStore = transactionIdStore;
     }
 
-    public void setStorageEngine(StorageEngine storageEngine) {
+    public void setStorageEngine( StorageEngine storageEngine ) {
         this.storageEngine = storageEngine;
     }
 
-    public void setLogFiles(LogFiles logFiles) {
+    public void setLogFiles( LogFiles logFiles ) {
         this.logFiles = logFiles;
     }
 
     public void initializeVersionContextSupplier() {
-        versionContextSupplier.init(transactionIdStore::getLastClosedTransactionId);
+        versionContextSupplier.init( transactionIdStore::getLastClosedTransactionId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
@@ -1,4 +1,5 @@
 package org.neo4j.kernel;
+import org.neo4j.io.pagecache.tracing.cursor.context.VersionContextSupplier;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -7,14 +8,15 @@ public class CoreBuildStore {
     private TransactionIdStore transactionIdStore;
     private StorageEngine storageEngine;
     private LogFiles logFiles;
+    private VersionContextSupplier versionContextSupplier;
 
-    public CoreBuildStore( TransactionIdStore transactionIdStore, StorageEngine storageEngine, LogFiles logFiles ) {
+    public CoreBuildStore(TransactionIdStore transactionIdStore, StorageEngine storageEngine,
+                          LogFiles logFiles, VersionContextSupplier versionContextSupplier) {
         this.transactionIdStore = transactionIdStore;
         this.storageEngine = storageEngine;
         this.logFiles = logFiles;
+        this.versionContextSupplier = versionContextSupplier;
     }
-
-    public CoreBuildStore() {}
 
     public TransactionIdStore getTransactionIdStore() {
         return transactionIdStore;
@@ -38,5 +40,9 @@ public class CoreBuildStore {
 
     public void setLogFiles(LogFiles logFiles) {
         this.logFiles = logFiles;
+    }
+
+    public void initializeVersionContextSupplier() {
+        versionContextSupplier.init(transactionIdStore::getLastClosedTransactionId);
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
@@ -1,0 +1,34 @@
+package org.neo4j.kernel;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+
+public class CoreBuildStore {
+    private TransactionIdStore transactionIdStore;
+    private StorageEngine storageEngine;
+    private LogFiles logFiles;
+
+    public CoreBuildStore( TransactionIdStore transactionIdStore, StorageEngine storageEngine, LogFiles logFiles ) {
+        this.transactionIdStore = transactionIdStore;
+        this.storageEngine = storageEngine;
+        this.logFiles = logFiles;
+    }
+
+    public CoreBuildStore() {}
+
+    public TransactionIdStore getTransactionIdStore() {
+        return transactionIdStore;
+    }
+
+    public StorageEngine getStorageEngine() {
+        return storageEngine;
+    }
+
+    public LogFiles getLogFiles() {
+        return logFiles;
+    }
+
+    public void setTransactionIdStore(TransactionIdStore transactionIdStore) {
+        this.transactionIdStore = transactionIdStore;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/CoreBuildStore.java
@@ -31,4 +31,12 @@ public class CoreBuildStore {
     public void setTransactionIdStore(TransactionIdStore transactionIdStore) {
         this.transactionIdStore = transactionIdStore;
     }
+
+    public void setStorageEngine(StorageEngine storageEngine) {
+        this.storageEngine = storageEngine;
+    }
+
+    public void setLogFiles(LogFiles logFiles) {
+        this.logFiles = logFiles;
+    }
 }


### PR DESCRIPTION
This request addresses issue #1.

The purpose of the changes in this request is to mitigate a code design flaw, or *smell*, known as long parameter lists in the `NeoStoreDataSource` class. Long parameter lists occur when an excessive number of arguments are passed into a class or method, which can result in code that is both harder to read and maintain. 

We are focusing on `NeoStoreDataSource.java` for this refactoring because it was identified by an online tool called codescene as being a refactoring target. Codescene determined that the code in this class is relatively complicated, and also that changes are frequently made to it. Because of these two factors, a significant amount of development time and effort likely goes into working on `NeoStoreDataSource.java`. Refactoring this class to make it easier to understand can therefore reduce the amount of development resources that are spent on this code over the long run.

The long parameter list smell is being addressed because an IDE tool designed to search for code smells, named Sonar Lint, flagged several cases of it. Sonar Lint recommends that a maximum of 7 parameters are given to methods or classes, and there are multiple parameter lists which exceed this amount in `NeoStoreDataSource.java`.

Our general approach to address this smell has been to find groups of parameters that are common within multiple parameter lists, enclose them within a new class, and pass this class in as a parameter instead.

* Commit 74106c8 creates a new class we have named `CoreBuildStore` to contain the parameters `StorageEngine`, `TransactionIdStore`, and `LogFiles`. These three parameters are then removed from the list given to the method `buildRecovery()` and are replaced with `CoreBuildStore`.

* Commit d9e1d33 performs a similar refactoring by replacing `StorageEngine`, `TransactionIdStore`, and `LogFiles` again with `CoreBuildStore` in the `buildKernel()` and `buildTransactionLogs()` methods' parameter lists. In addition, unnecessary redundant variable assignments and deprecated method calls were removed as recommended by Sonar Lint.



 
